### PR TITLE
Remove Portland from the chapters dropdown

### DIFF
--- a/coming_soon.html
+++ b/coming_soon.html
@@ -117,7 +117,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/contact.html
+++ b/contact.html
@@ -128,7 +128,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/current_rulebook.html
+++ b/current_rulebook.html
@@ -126,7 +126,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/events.html
+++ b/events.html
@@ -127,7 +127,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/first_event.html
+++ b/first_event.html
@@ -130,7 +130,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/index.html
+++ b/index.html
@@ -133,7 +133,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/player_information.html
+++ b/player_information.html
@@ -130,7 +130,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>

--- a/start_a_chapter.html
+++ b/start_a_chapter.html
@@ -130,7 +130,6 @@
 		  <a href="https://www.refugelarpboise.com" target="new" class="dropdown-item">Boise</a>
           <a href="https://www.refugelarpcalgary.ca" target="new" class="dropdown-item">Calgary</a>
           <a href="https://www.refugelarpedmonton.ca" target="new" class="dropdown-item">Edmonton</a>
-          <a href="https://www.refugelarpportland.com" target="new" class="dropdown-item">Portland</a>
           <a href="https://www.refugelarpsaltlake.com" target="new" class="dropdown-item">Salt Lake</a>
                     <a href="https://www.refugelarpsanfransico.com" target="new" class="dropdown-item">San Francisco</a>
           <a href="https://www.refugelarpseattle.com" target="new" class="dropdown-item">Seattle</a>


### PR DESCRIPTION
The Portland chapter is no longer open, and so needs to be removed from the website.